### PR TITLE
Adds an audit process to Jira for specified projects. PD-1784

### DIFF
--- a/jiratools.py
+++ b/jiratools.py
@@ -165,7 +165,6 @@ class Housekeeping():
            
             # close the INDEXREP ticket
             close_me = self.close_issue(link_back)
-            print close_me
             
             # add comment to indexrep ticket
             link_back_comment = "This issue has been closed. The audit ticket is %s" % new_issue

--- a/jiratools.py
+++ b/jiratools.py
@@ -22,8 +22,8 @@ class Housekeeping():
     def __init__(self):
         # class variables
         self.ac_label =  u'auto-close-24-hours'
-        self.audit_delay = '0h'
-        self.audit_projects = "TEST" #comma delimited project keys
+        self.audit_delay = '-72h'
+        self.audit_projects = "INDEXREP" #comma delimited project keys
         # open JIRA API Connection
         self.jira = JIRA(options=secrets.options, 
                             basic_auth=secrets.housekeeping_auth) 
@@ -74,7 +74,10 @@ class Housekeeping():
         for issue in issues:
             link_list = [issue.key,] # first linked ticket should be this audit ticket
             for link in issue.fields.issuelinks: # grab the rest of links
-                link_list.append(link.outwardIssue.key)
+                try:
+                    link_list.append(link.outwardIssue.key)
+                except AttributeError:
+                    pass
             
             # capture orignal tick and project
             original_ticket = issue.fields.summary.split("[")[1].split("]")[0]
@@ -312,16 +315,16 @@ class Housekeeping():
             
     def close_issue(self, issue):
         """
-        Closes the issue passed to it.
+        Closes the issue passed to it with a resolution of fixed.
         Inputs: Issue: the issue object to close
-        Returs: True|False
+        Returns: True|False
         
         """
         trans = self.jira.transitions(issue)
         success_flag = False
         for tran in trans:
             if 'close' in tran['name'].lower():
-                self.jira.transition_issue(issue,tran['id'])
+                self.jira.transition_issue(issue,tran['id'],{'resolution':{'id':'1'}})
                 success_flag = True
         return success_flag
                 

--- a/jiratools.py
+++ b/jiratools.py
@@ -134,7 +134,7 @@ class Housekeeping():
         else:
             # for now, throw an error. Later, assign to user with fewer ADT tickets
             # this will also mean turning the code in auto_assign into a method (DRY)
-            return "Error: There is more than possible auditor"
+            return "Error: There is more than one possible auditor"
         
         # cycle through them and create a new ADT ticket for each 
         for issue in issues:

--- a/jiratools.py
+++ b/jiratools.py
@@ -3,7 +3,7 @@ Jira Housekeeping (c)2014 DirectEmployers Association. See README
 for license info.
 
 Reference for using the jira client:
-http://jira-python.readthedocs.org/en/latest/
+http://pythonhosted.org/jira/
 
 """
 from datetime import datetime
@@ -27,11 +27,11 @@ class Housekeeping():
                             basic_auth=secrets.housekeeping_auth) 
     
         # commands to run
-        self.content_acquisition_auto_qc()
-        self.auto_assign()
-        self.remind_reporter_to_close()
-        self.close_resolved()
-        self.clear_auto_close_label()
+        #self.content_acquisition_auto_qc()
+        #self.auto_assign()
+        #self.remind_reporter_to_close()
+        #self.close_resolved()
+        #self.clear_auto_close_label()
 
     def content_acquisition_auto_qc(self):
         """
@@ -52,7 +52,143 @@ class Housekeeping():
             """
             self.jira.transition_issue(issue.key,'771')
             self.jira.add_comment(issue.key, message)
-
+    
+    def handle_audited_tickets(self):
+        #return True #keep it running. remove once the method runs
+        # look up failed audits. We only care about failed ADT tickets.
+        issues = self.jira.search_issues(
+            'project=ADT and status="Failed Audit"')
+        # generate new indexrep ticket
+        for issue in issues:            
+            link_list = [issue.key,]
+            for link in issue.fields.issuelinks:
+                link_list.append(link.outwardIssue.key)            
+            indexrep_summary = issue.fields.summary
+            original_ticket = issue.fields.summary.split("(")[1].split(")")[0]
+            indexrep_summary = indexrep_summary.replace("compliance audit - ","")
+            indexrep_summary = ' %s - Failed Audit' % (indexrep_summary)
+            message = 'This issue failed audit. Please review %s and make any necessary corrections.' % original_ticket            
+            watcher_list = [issue.fields.assignee.key,]
+            for w in self.jira.watchers(issue).watchers:
+                watcher_list.append(w.key)
+            watcher_list = set(watcher_list)
+            reporter = issue.fields.reporter.key
+            print indexrep_summary
+            print issue
+            print link_list
+            print reporter
+            print message
+            print watcher_list
+            #new_issue = self.make_new_issue("INDEXREP",qa_auditor,reporter,adt_summary,message,watcher_list,[link_back])
+            #original_assignee = issue.fields.assignee.key
+            #generate list of linked issues. Include this issue
+            #capture the report
+            
+        # link it to ADT and original INDEXREP ticket
+        # make it unassigned
+        # transfer watchers of original INDEXREP ticket, but not the assignee from the ADT ticket
+        # reporter should be same as ADT
+        # assignee unassigned
+        # comment on the ADT ticket with the new ticket value and the original INDEXREP issue
+        # close the ADT ticket
+    
+    def content_acquisition_3day_audit(self):
+        """
+        TAKES INDEXREP issues that have been resolved for 72 hours and creates
+        a new ticket in AUDIT, closes the INDEXREP ticket, and then assigns it
+        to the audit user specified in the self.qa_auditor role.
+        841
+        
+        """
+        # get all the INDERXREP issues
+        issues = self.jira.search_issues(
+            'project=TEST and status=Resolved')# and resolutiondate<="-72h"')
+        qa_members = self.get_group_members("issue audits")
+        if len(qa_members)==1:
+            qa_auditor=qa_members.keys()[0]
+        else:
+            # for now, throw an error. Later, assign to user with fewer ADT tickets
+            # this will also mean turning the code in auto_assign into a method (DRY)
+            return "Error: There is more than possible auditor"
+        
+        # cycle through them and create a new ADT ticket for each        
+        for issue in issues:
+            link_back = issue.key
+            adt_summary = 'compliance audit - %s (%s)' % (issue.fields.summary,link_back)
+            message = '[~%s], this issue is ready to audit.' % qa_auditor
+            watcher_list = []
+            for w in self.jira.watchers(issue).watchers:
+                watcher_list.append(w.key)
+            reporter = issue.fields.reporter.key
+            original_assignee = issue.fields.assignee.key
+            # debug info for dev feedback
+            #print 'Key: %s \n    Summary: %s \n    Message: %s \n    Watchers of ADT: %s, \n    Reporter: %s \n    Assignee: %s \n    Original Assignee: %s \n------------------\n' % (link_back, adt_summary, message, watcher_list, reporter, qa_auditor, original_assignee)
+            #print 'Actions: \n    - %s issue will be closed\n    - a new ADT ticket will be created\n    - The ADT ticket will be assigned\n    - Watchers will include all original watchers + original assignee' % (link_back)
+            #print '    - reporter will be original reporter'
+            #print '    - new ADT will link to %s' % link_back
+            #print '+++++++++++++++++++++++++'            
+           
+            # make the audit ticket
+            new_issue = self.make_new_issue("ADT",qa_auditor,reporter,adt_summary,message,watcher_list,[link_back])
+           
+            # close the INDEXREP ticket
+            close_me = self.close_issue(link_back)
+            print close_me
+            
+            # add comment to indexrep ticket
+            link_back_comment = "This issue has been closed. The audit ticket is %s" % new_adt
+            self.jira.add_comment(link_back, link_back_comment)
+        
+    def make_new_issue(self,project,issue_assignee,issue_reporter,summary,description="",watchers=[],links=[],issuetype="Task"):
+        """
+        Creates a new issue with the given parameters.
+        Inputs:
+        *REQUIRED*
+            :project:   the jirs project key in which to create the issue
+            :issue_assignee:    user name who the issue will be assigned to
+            :issue_reporter:    user name of the issue report
+            :summary:   string value of the issue summary field
+            *OPTIONAL*
+            :description: Issue description. Defaults to empty string
+            :watchers: list of user names to add as issue watchers
+            :link:  list of issue keys to link to the issue as "Related To"
+            :issuetype: the type of issue to create. Defaults to type.
+        Returns: Jira Issue Object
+        
+        """
+        issue_dict = {
+            'project':{'key':project},
+            'summary': adt_summary,
+            'issuetype': {'name':issuetype},
+            'description':description,        
+            }
+        new_issue = self.jira.create_issue(fields=audit_dict)
+        
+        # assign the audit tick to auditor
+        new_issue.update(assignee={'name':,issue_assignee})
+        new_issue.update(reporter={'name':issue_reporter})
+        
+        # add watchers to audit ticket (reporter, assignee, wacthers from indexrep ticket)
+        for watcher in watchers:
+            self.jira.add_watcher(new_issue,watcher)
+        
+        # link the audit ticket back to indexrep ticket
+        for link in links:
+            self.jira.create_issue_link('Relates',new_issue,link)
+            
+        return new_issue
+            
+    # method to transistion audit ticket    
+    def get_group_members(self, group_name):
+        """
+        Returns the members of a 
+        """
+        group = self.jira.groups(
+            query=group_name
+            )['groups'][0]['name']
+        members = self.jira.group_members(group)
+        return members
+        
     def auto_assign(self):
         """
         Looks up new INDEXREP issues with an empty assignee and non-agent
@@ -60,10 +196,12 @@ class Housekeeping():
         group with the fewest assigned contect-acquistion tickets. 
 
         """
-        ca_group = self.jira.groups(
-            query='content-acquisition'
-            )['groups'][0]['name']
-        members = self.jira.group_members(ca_group)
+        #ca_group = self.jira.groups(
+        #    query='content-acquisition'
+        #    )['groups'][0]['name']
+        #members = self.jira.group_members(ca_group)        
+        members = self.get_group_members('content-acquisition')
+        
         issues = self.jira.search_issues(
             'project=INDEXREP and (assignee=EMPTY OR assignee=housekeeping) and \
              status in (open,reopened) and reporter != contentagent and \
@@ -134,11 +272,23 @@ class Housekeeping():
             AND updated <= -24h \
             AND labels in (auto-close-24-hours)')
         for issue in issues:
-            trans = self.jira.transitions(issue)
-            for tran in trans:
-                if 'close' in tran['name'].lower():
-                    self.jira.transition_issue(issue,tran['id'])
-
+            close_me = self.close_issue(issue)
+            
+    def close_issue(self, issue):
+        """
+        Closes the issue passed to it.
+        Inputs: Issue: the issue object to close
+        Returs: True|False
+        
+        """
+        trans = self.jira.transitions(issue)
+        success_flag = False
+        for tran in trans:
+            if 'close' in tran['name'].lower():
+                self.jira.transition_issue(issue,tran['id'])
+                success_flag = True
+        return success_flag
+                
     def clear_auto_close_label(self):
         """
         Clears the auto-close label from issues that have been re-opened

--- a/jiratools.py
+++ b/jiratools.py
@@ -183,7 +183,7 @@ class Housekeeping():
         Creates a new issue with the given parameters.
         Inputs:
         *REQUIRED*
-            :project:   the jirs project key in which to create the issue
+            :project:   the jira project key in which to create the issue
             :issue_assignee:    user name who the issue will be assigned to
             :issue_reporter:    user name of the issue report
             :summary:   string value of the issue summary field

--- a/jiratools.py
+++ b/jiratools.py
@@ -66,6 +66,7 @@ class Housekeeping():
             indexrep_summary = issue.fields.summary
             original_ticket = issue.fields.summary.split("(")[1].split(")")[0]
             indexrep_summary = indexrep_summary.replace("compliance audit - ","")
+            indexrep_summary = indexrep_summary.split("(")[0]
             indexrep_summary = ' %s - Failed Audit' % (indexrep_summary)
             message = 'This issue failed audit. Please review %s and make any necessary corrections.' % original_ticket            
             watcher_list = [issue.fields.assignee.key,]
@@ -73,13 +74,15 @@ class Housekeeping():
                 watcher_list.append(w.key)
             watcher_list = set(watcher_list)
             reporter = issue.fields.reporter.key
-            print indexrep_summary
-            print issue
-            print link_list
-            print reporter
-            print message
-            print watcher_list
-            #new_issue = self.make_new_issue("INDEXREP",qa_auditor,reporter,adt_summary,message,watcher_list,[link_back])
+            #print indexrep_summary
+            #print issue
+            #print link_list
+            #print reporter
+            #print message
+            #print watcher_list
+            #make_new_issue(self,project,issue_assignee,issue_reporter,summary,description="",watchers=[],links=[],issuetype="Task"):
+            new_issue = self.make_new_issue("TEST","EMPTY",reporter,indexrep_summary,message,watcher_list,link_list)
+            print new_issue
             #original_assignee = issue.fields.assignee.key
             #generate list of linked issues. Include this issue
             #capture the report
@@ -97,7 +100,7 @@ class Housekeeping():
         TAKES INDEXREP issues that have been resolved for 72 hours and creates
         a new ticket in AUDIT, closes the INDEXREP ticket, and then assigns it
         to the audit user specified in the self.qa_auditor role.
-        841
+        
         
         """
         # get all the INDERXREP issues
@@ -158,14 +161,14 @@ class Housekeeping():
         """
         issue_dict = {
             'project':{'key':project},
-            'summary': adt_summary,
+            'summary': summary,
             'issuetype': {'name':issuetype},
             'description':description,        
             }
-        new_issue = self.jira.create_issue(fields=audit_dict)
+        new_issue = self.jira.create_issue(fields=issue_dict)
         
         # assign the audit tick to auditor
-        new_issue.update(assignee={'name':,issue_assignee})
+        new_issue.update(assignee={'name':issue_assignee})
         new_issue.update(reporter={'name':issue_reporter})
         
         # add watchers to audit ticket (reporter, assignee, wacthers from indexrep ticket)

--- a/jiratools.py
+++ b/jiratools.py
@@ -29,11 +29,11 @@ class Housekeeping():
                             basic_auth=secrets.housekeeping_auth) 
     
         # commands to run
-        #self.content_acquisition_auto_qc()
-        #self.auto_assign()
-        #self.remind_reporter_to_close()
-        #self.close_resolved()
-        #self.clear_auto_close_label()
+        self.content_acquisition_auto_qc()
+        self.auto_assign()
+        self.remind_reporter_to_close()
+        self.close_resolved()
+        self.clear_auto_close_label()
         self.resolved_issue_audit()
         self.handle_audited_tickets()
 


### PR DESCRIPTION
For a project (specifed in a class level var), take any issue that is resolved for X time period (also a class level variable) and do the following:
- close it
- create a new issue in the project ADT
- assign that issue to the user in the Jira Group "issue audits"
-- currently this script only handles a dingle audit user, and will throw an error message if there are too many. I have left a comment in the code where multi-assignee handling would go if there ever is a need for more than one person.
- preserve watchers from the original ticket to the audit ticket.
- link the original ticket and the audit ticket

Once the audit is complete, it will fall into one of two states: closed or "failed audit". If it is closed, then it passed audit, and nothing is needed. If it fails, do the following:
- close the audit ticket
- create a new ticket in the original project that links back to the audit ticket and original ticket
- preserve watchers in the new ticket from the original ticket

In addition, I have made some other modifications to keep with DRY practices, notably pulling lists of watchers, creating, and closing issues.