### PR TITLE
Normalize assignment PD-2316

### DIFF
--- a/jiratools.py
+++ b/jiratools.py
@@ -280,9 +280,16 @@ class Housekeeping():
         group with the fewest assigned contect-acquistion tickets. 
 
         """        
-        # filter 20702 returns issues that need to auto assigned
+        # filter 20702 returns member issues that need to auto assigned
         jql_query = self.jira.filter("20702").jql        
-        issues = self.jira.search_issues(jql_query)
+        mem_issues = self.jira.search_issues(jql_query)
+        
+        #filter 21400 returns non-member issues that need to be assigned
+        jql_query = self.jira.filter("21400").jql        
+        nm_issues = self.jira.search_issues(jql_query)
+        
+        #merge the lists so that members are first
+        issues = mem_issues + nm_issues
         
         #filter 21200 returns non-resolved assigned issues
         assigned_issues_query = self.jira.filter("21200").jql
@@ -300,7 +307,7 @@ class Housekeeping():
                 "to [~%s].") % (reporter,username)
             self.jira.add_comment(issue.key, message)
             self.toggle_watchers("add",issue,watch_list)
-           
+            
         
     def remind_reporter_to_close(self):
         """

--- a/jiratools.py
+++ b/jiratools.py
@@ -29,13 +29,13 @@ class Housekeeping():
                             basic_auth=secrets.housekeeping_auth) 
     
         # commands to run
-        #self.content_acquisition_auto_qc()
+        self.content_acquisition_auto_qc()
         self.auto_assign()
-        #self.remind_reporter_to_close()
-        #self.close_resolved() 
-        #self.clear_auto_close_label()
-        #self.resolved_issue_audit()
-        #self.handle_audited_tickets()
+        self.remind_reporter_to_close()
+        self.close_resolved() 
+        self.clear_auto_close_label()
+        self.resolved_issue_audit()
+        self.handle_audited_tickets()
 
     def content_acquisition_auto_qc(self):
         """


### PR DESCRIPTION
Modified auto-assignment of INDEXREP tickets such that:

- Assigned tickets counts are re-calculated after each ticket assignment instead of only once at the beginning
- member tickets are processed first