### PR TITLE
Dynamic defaults for Indexing Type

### DIFF
--- a/jiratools.py
+++ b/jiratools.py
@@ -342,6 +342,15 @@ class Housekeeping():
             reporter = issue.fields.reporter.key
             watch_list = self.toggle_watchers("remove",issue)
             self.jira.assign_issue(issue=issue,assignee=username)
+            free_index_mem = self.get_group_members("free-index-default")
+            if issue.fields.customfield_10500 == None:
+                if reporter in free_index_mem:
+                    issue.update({"customfield_10500":{"id":"10100"}}) #free
+                else:
+                    issue.update({"customfield_10500":{"id":"10103"}}) #member
+                    
+            # look at indexing type (field 10500) and set it to member if empty
+            # or to free if user is in free indexing group (need to create)
             message = ("[~%s], this issue has been automically assigned "
                 "to [~%s].") % (reporter,username)
             self.jira.add_comment(issue.key, message)

--- a/jiratools.py
+++ b/jiratools.py
@@ -342,6 +342,10 @@ class Housekeeping():
             reporter = issue.fields.reporter.key
             watch_list = self.toggle_watchers("remove",issue)
             self.jira.assign_issue(issue=issue,assignee=username)
+            
+            # if the reporter is in free-index-default group, and indexing type
+            # is not set, default indexing type to free (10100). Otherwise, 
+            # default to member. In all cases, no change if it's already set
             free_index_mem = self.get_group_members("free-index-default")
             if issue.fields.customfield_10500 == None:
                 if reporter in free_index_mem:
@@ -349,8 +353,6 @@ class Housekeeping():
                 else:
                     issue.update({"customfield_10500":{"id":"10103"}}) #member
                     
-            # look at indexing type (field 10500) and set it to member if empty
-            # or to free if user is in free indexing group (need to create)
             message = ("[~%s], this issue has been automically assigned "
                 "to [~%s].") % (reporter,username)
             self.jira.add_comment(issue.key, message)


### PR DESCRIPTION
When auto assigning an issue, applies the following logic:

If indexing type is already set: Do nothing
If indexing type == None and reporter is in free-index-default jira group: indexing type = Free
If indexing type == None and reporter in NOT in free-index-default jira group: indexing type = member