### PR TITLE
Move new member setup string match list to external file

### DIFF
--- a/jiratools.py
+++ b/jiratools.py
@@ -11,7 +11,7 @@ from jira.client import JIRA
 import logging
 import operator
 import secrets
-
+import settings
 
 class Housekeeping():
     """
@@ -187,7 +187,8 @@ class Housekeeping():
             
             # check reporter to see if special consideration is needed
             # if reporter is not MS or MD, or it's a new member, assign to audit lead.
-            new_member_setup = self.check_for_text(issue,["new member setup","setup member"])
+            new_member_setup = self.check_for_text(issue,
+                                                   settings.member_setup_strs)
             assigned_audit_tasks_query = self.jira.filter("24922").jql
             if reporter not in member_all or new_member_setup:
                 qa_auditor = self.user_with_fewest_issues('issue audits lead', 

--- a/settings.py
+++ b/settings.py
@@ -1,0 +1,7 @@
+# list used to match audit tickets as new member setup tasks
+member_setup_strs=[
+    "new member setup",
+    "setup member",
+    "set up member",
+    "set up new member"
+    ]


### PR DESCRIPTION
This makes edits easier in the future.  We need to modify the text matching based on what is put it in the tickets, and it's easier and safer to have these in an external list than to modify the matching logic every time. 