### PR TITLE
Remove filter IDs from main app

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -1,4 +1,3 @@
-import secrets
 # list used to match audit tickets as new member setup tasks
 member_setup_strs=[
     "new member setup",

--- a/settings.py
+++ b/settings.py
@@ -1,3 +1,4 @@
+import secrets
 # list used to match audit tickets as new member setup tasks
 member_setup_strs=[
     "new member setup",


### PR DESCRIPTION
This PR modifies the filter usage such that filter IDs are no longer used directly in the code and are instead contained in a dict stored in the secrets file. I did this (as opposed to settings), on the off chance that knowing the filter ids could provide hackers with access to Jira.