### PR TITLE
Modify the auto assign Fn to work with N projects. SE-72 SE-57

### DIFF
--- a/jiratools.py
+++ b/jiratools.py
@@ -373,7 +373,6 @@ class Housekeeping():
             self.jira.add_comment(issue.key, message)
             self.toggle_watchers("add",issue,watch_list)
 
-
         auto_assign_dicts = [
             {
                 "issue_list": mem_issues,
@@ -394,9 +393,7 @@ class Housekeeping():
                 "issue_list": se_issues,
                 "assigned_list": se_assigned_issues_query,
                 "assignee_group": "se-assignees",
-            }
-
-        ]
+            }]
 
         for list in auto_assign_dicts:
             for issue in list["issue_list"]:

--- a/jiratools.py
+++ b/jiratools.py
@@ -337,33 +337,21 @@ class Housekeeping():
         group with the fewest assigned contect-acquistion tickets.
 
         """
-        #make this project agnostic
-
-
-        # add switch for project
-
-        """ this needs to be a method to build the issue list and return is as an object"""
         # get member INDEXREP issues that need to auto assigned
         mem_issues = self.get_issues("member_auto_assign")
-
         # get free indexing requests
         free_issues = self.get_issues("free_auto_assign")
-
         # get unassigned member engagement issues
         mer_issues = self.get_issues("mer_auto_assign")
-
         # get unassigned sales engineering issues
         se_issues = self.get_issues("se_auto_assign")
 
         # get non-resolved assigned Member issues
         member_assigned_issues_query = self.get_issues("member_assigned_issues",True)
-
         # get non-resolved assigned Free Indexing issues
         free_assigned_issues_query = self.get_issues("free_assigned_issues",True)
-
         # get non-resolved member enagement issues
         mer_assigned_issues_query = self.get_issues("mer_assigned_issues",True)
-
         # get non-resolved sales engineering issues
         se_assigned_issues_query = self.get_issues("se_assigned_issues",True)
 
@@ -430,7 +418,7 @@ class Housekeeping():
 
                 _assign(issue,username)
 
-        
+
     def remind_reporter_to_close(self):
         """
         Comments on all non-closed resolved issues that are 13 days without a


### PR DESCRIPTION
This makes the following modification to the auto_assign method:

- replaces multiple for loops with single for loop powered by a dictionary
- adds references to additional saved Jira searches for auto assigning SE and MER tickets
- moves indexing specific code out of the _assign sub routine and into an if statement in order to make _assign project agnostic.

End result is that the auto assign function is now setup to work for any jira project we want to point it at instead of being customized to just the indexing and free indexing projects.

I have tested this locally, and all 4 projects being auto assigned by this method are functioning correctly.

This functionality is dependent on changes to the secrets.py file, which contains the internal search IDs of the quires used in the method.