### PR TITLE
Add logic to add default watchers to auto-assigned tickets

### DIFF
--- a/jiratools.py
+++ b/jiratools.py
@@ -388,6 +388,7 @@ class Housekeeping():
                 "issue_list": mer_issues,
                 "assigned_list": mer_assigned_issues_query,
                 "assignee_group": "mer-assignees",
+                "watch_list":"mer-auto-watch",
             },
             {
                 "issue_list": se_issues,
@@ -414,7 +415,10 @@ class Housekeeping():
                         issue.update({"customfield_10500":{"id":"10103"}})
 
                 _assign(issue,username)
-
+                # if the dict object has a watch list item, add default watchers
+                if "watch_list" in auto_assign_dict:
+                    watchers = self.get_group_members(auto_assign_dict["watch_list"])
+                    self.toggle_watchers("add",issue,watchers)
 
     def remind_reporter_to_close(self):
         """
@@ -525,10 +529,10 @@ class Housekeeping():
         if action=="remove":
             issue_watchers = self.jira.watchers(issue).watchers
             for issue_watcher in issue_watchers:
-                self.jira.remove_watcher(issue,issue_watcher.name)
+                self.jira.remove_watcher(issue,issue_watcher)
         else:
             for old_watcher in watch_list:
-                self.jira.add_watcher(issue,old_watcher.name)
+                self.jira.add_watcher(issue,old_watcher)
             issue_watchers = self.jira.watchers(issue).watchers
         return issue_watchers
 

--- a/jiratools.py
+++ b/jiratools.py
@@ -364,14 +364,11 @@ class Housekeeping():
 
             """
             reporter = issue.fields.reporter.key
-            project = issue.key.split("-")[0]
-            watch_list = self.toggle_watchers("remove",issue)
             self.jira.assign_issue(issue=issue,assignee=username)
 
             message = ("[~%s], this issue has been automically assigned "
                 "to [~%s].") % (reporter,username)
             self.jira.add_comment(issue.key, message)
-            self.toggle_watchers("add",issue,watch_list)
 
         auto_assign_dicts = [
             {
@@ -414,11 +411,13 @@ class Housekeeping():
                     else: #default is member otherwise
                         issue.update({"customfield_10500":{"id":"10103"}})
 
-                _assign(issue,username)
                 # if the dict object has a watch list item, add default watchers
                 if "watch_list" in auto_assign_dict:
                     watchers = self.get_group_members(auto_assign_dict["watch_list"])
                     self.toggle_watchers("add",issue,watchers)
+
+                _assign(issue,username)
+
 
     def remind_reporter_to_close(self):
         """


### PR DESCRIPTION
Now default assignees can be set for each of the auto-assignment dictionary objects. Also corrects an API bug in the toggle watchers method.