### PR TITLE
update watcher toggle to handle multiple watch_list contents. SE-82

### DIFF
--- a/jiratools.py
+++ b/jiratools.py
@@ -533,10 +533,18 @@ class Housekeeping():
         if action=="remove":
             issue_watchers = self.jira.watchers(issue).watchers
             for issue_watcher in issue_watchers:
-                self.jira.remove_watcher(issue,issue_watcher)
+                # watch list can be inconsensent when returned by the jira api
+                # same issue in the add loop
+                try:
+                    self.jira.remove_watcher(issue,issue_watcher.name)
+                except AttributeError:
+                    self.jira.add_watcher(issue,old_watcher)
         else:
             for old_watcher in watch_list:
-                self.jira.add_watcher(issue,old_watcher)
+                try:
+                    self.jira.add_watcher(issue,old_watcher.name)
+                except AttributeError:
+                    self.jira.add_watcher(issue,old_watcher)
             issue_watchers = self.jira.watchers(issue).watchers
         return issue_watchers
 


### PR DESCRIPTION
Watch_list can contain different objects based on how it is built. The Jira API does it one way when you pull a watch list, but does it another when you build the list from a set of users. The objects in question are specific jira objects, so we need to be able to handle both.